### PR TITLE
Android-specific model and manufacturer + iOS-specific hardwareVersion

### DIFF
--- a/backends/capabilities_android/capabilities/Capabilities.hx
+++ b/backends/capabilities_android/capabilities/Capabilities.hx
@@ -56,6 +56,10 @@ class Capabilities
     "isPhone", "()Z");
     private static var getPreferredLanguageNative = JNI.createStaticMethod("org/haxe/duell/capabilities/Capabilities",
     "getPreferredLanguage", "()Ljava/lang/String;");
+    private static var getModelNative = JNI.createStaticMethod("org/haxe/duell/capabilities/Capabilities",
+    "getModel", "()Ljava/lang/String;");
+    private static var getManufacturerNative = JNI.createStaticMethod("org/haxe/duell/capabilities/Capabilities",
+    "getManufacturer", "()Ljava/lang/String;");
 
     private static var psInstance: Capabilities;
 
@@ -85,6 +89,10 @@ class Capabilities
 
     public var preferredLanguage(get, never): String;
     public var isRooted(get, never): Bool;
+
+    // Android-specific
+    public var androidModel(get, never): String;
+    public var androidManufacturer(get, never): String;
 
     private function new(callback: Void -> Void)
     {
@@ -228,5 +236,15 @@ class Capabilities
     private function get_isRooted(): Bool
     {
         return isRootedDevice();
+    }
+
+    private function get_androidModel(): String
+    {
+        return getModelNative();
+    }
+
+    private function get_androidManufacturer(): String
+    {
+        return getManufacturerNative();
     }
 }

--- a/backends/capabilities_android/java/org/haxe/duell/capabilities/Capabilities.java
+++ b/backends/capabilities_android/java/org/haxe/duell/capabilities/Capabilities.java
@@ -156,6 +156,26 @@ public final class Capabilities
     }
 
     /**
+     * Retrieves the device model.
+     *
+     * @return the device model
+     */
+    public static String getModel()
+    {
+        return Build.MODEL;
+    }
+
+    /**
+     * Retrieves the device manufacturer.
+     *
+     * @return the device manufacturer
+     */
+    public static String getManufacturer()
+    {
+        return Build.MANUFACTURER;
+    }
+
+    /**
      * Retrieves the device name, with manufacturer and model.
      *
      * @return the pretty-print of the device name

--- a/backends/capabilities_android/proguard.cfg
+++ b/backends/capabilities_android/proguard.cfg
@@ -3,8 +3,7 @@
 #
 
 	-keep class org.haxe.duell.capabilities.Capabilities
-    -keepclassmembers class org.haxe.duell.capabilities.Capabilities
-	{
+    -keepclassmembers class org.haxe.duell.capabilities.Capabilities {
 		public static int getResolutionX();
 		public static int getResolutionY();
 		public static double getDensity();
@@ -12,10 +11,12 @@
 		public static boolean isRootedDevice();
 		public static boolean isPhone();
 		public static void retrieveAdvertisementId(org.haxe.duell.hxjni.HaxeObject);
-		public static static java.lang.String getSerial();
-		public static static java.lang.String getSystemVersion();
-		public static static java.lang.String getDeviceModel();
-		public static static java.lang.String getPreferredLanguage();
+		public static java.lang.String getSerial();
+		public static java.lang.String getSystemVersion();
+		public static java.lang.String getDeviceModel();
+		public static java.lang.String getPreferredLanguage();
+		public static java.lang.String getModel();
+		public static java.lang.String getManufacturer();
 		public static double getTotalMemory();
 	}
 

--- a/backends/capabilities_ios/capabilities/Capabilities.hx
+++ b/backends/capabilities_ios/capabilities/Capabilities.hx
@@ -45,6 +45,7 @@ class Capabilities
     private static var isLandscapeNative = Lib.load("ioscapabilities","ioscapabilities_isLandscapeNative",0);
     private static var isIPhoneNative = Lib.load("ioscapabilities","ioscapabilities_isIPhone",0);
     private static var isRootedDevice = Lib.load("ioscapabilities","ioscapabilities_isJailbroken",0);
+    private static var getHardwareVersionNative = Lib.load("ioscapabilities","ioscapabilities_getHardwareVersion",0);
 
     private static var psInstance: Capabilities = null;
 
@@ -70,6 +71,9 @@ class Capabilities
     public var preferredLanguage(get, never): String;
 
     public var isRooted(get, never): Bool;
+
+    // ios-specific
+    public var iOSHardwareVersion(get, never): String;
 
     private function new()
     {}
@@ -199,5 +203,10 @@ class Capabilities
     private function get_isRooted(): Bool
     {
         return isRootedDevice();
+    }
+
+    private function get_iOSHardwareVersion(): String
+    {
+        return getHardwareVersionNative();
     }
 }


### PR DESCRIPTION
I've added extra fields which are not exposed through the extern as they are very particular to the platform they're running in.
This is why they are trailed with android- and ios-, respectively.
